### PR TITLE
added FullyConnected_bf_tiled::GetUpdateDispatchDataFunc

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -486,33 +486,37 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
 }
 
 void FullyConnected_bf_tiled::GetUpdateDispatchDataFunc(KernelData& kd) const {
-    kd.update_dispatch_data_func = [this](const Params& params, KernelData& kd) {
-        const auto& prim_params = static_cast<const fully_connected_params&>(params);
+    if (kd.kernels.size() == 1) {
+        Parent::GetUpdateDispatchDataFunc(kd);
+    } else {
+        kd.update_dispatch_data_func = [this](const Params& params, KernelData& kd) {
+            const auto& prim_params = static_cast<const fully_connected_params&>(params);
 
-        OPENVINO_ASSERT(kd.kernels.size() == 2, "[GPU] Invalid kernels size for update dispatch data func, expected 2, got ", kd.kernels.size());
+            OPENVINO_ASSERT(kd.kernels.size() == 2, "[GPU] Invalid kernels size for update dispatch data func, expected 2, got ", kd.kernels.size());
 
-        size_t output_batch = prim_params.outputs[0].Batch().v;
-        if (prim_params.outputs[0].GetLayout() == DataLayout::bfyx)
-            output_batch *= prim_params.outputs[0].Feature().v;
+            size_t output_batch = prim_params.outputs[0].Batch().v;
+            if (prim_params.outputs[0].GetLayout() == DataLayout::bfyx)
+                output_batch *= prim_params.outputs[0].Feature().v;
 
-        // Choose one of the two shape agnostic kernels:
-        // - kd.kernels[0] for batches <= 240 (default version)
-        // - kd.kernels[1] for batches >= 256 (slm version)
-        const auto default_alignment = 16;
-        // We can use SLM version if `output_batch + default_alignment > 256` because memory and batch are aligned (whether 16 or 64 elements)
-        const auto skip_kernel_idx = output_batch + default_alignment > 256 ? 0 : 1;
-        const auto execute_kernel_idx = 1 - skip_kernel_idx;
+            // Choose one of the two shape agnostic kernels:
+            // - kd.kernels[0] for batches <= 240 (default version)
+            // - kd.kernels[1] for batches >= 256 (slm version)
+            const auto default_alignment = 16;
+            // We can use SLM version if `output_batch + default_alignment > 256` because memory and batch are aligned (whether 16 or 64 elements)
+            const auto skip_kernel_idx = output_batch + default_alignment > 256 ? 0 : 1;
+            const auto execute_kernel_idx = 1 - skip_kernel_idx;
 
-        kd.kernels[skip_kernel_idx].skip_execution = true;
+            kd.kernels[skip_kernel_idx].skip_execution = true;
 
-        GPU_DEBUG_TRACE_DETAIL << "FC bf tiled: " << (execute_kernel_idx == 1 ? "SLM" : "Default") << " shape-agnostic kernel version "
-                                << "will be used for batch size = " << output_batch << "\n";
+            GPU_DEBUG_TRACE_DETAIL << "FC bf tiled: " << (execute_kernel_idx == 1 ? "SLM" : "Default") << " shape-agnostic kernel version "
+                                    << "will be used for batch size = " << output_batch << "\n";
 
-        auto dispatchData = SetDefault(prim_params, -1, execute_kernel_idx);
-        kd.kernels[execute_kernel_idx].params.workGroups.global = dispatchData.gws;
-        kd.kernels[execute_kernel_idx].params.workGroups.local = dispatchData.lws;
-        kd.kernels[execute_kernel_idx].skip_execution = KernelData::SkipKernelExecution(prim_params);
-    };
+            auto dispatchData = SetDefault(prim_params, -1, execute_kernel_idx);
+            kd.kernels[execute_kernel_idx].params.workGroups.global = dispatchData.gws;
+            kd.kernels[execute_kernel_idx].params.workGroups.local = dispatchData.lws;
+            kd.kernels[execute_kernel_idx].skip_execution = KernelData::SkipKernelExecution(prim_params);
+        };
+    }
 }
 
 KernelsData FullyConnected_bf_tiled::GetTunedKernelsDataByIndex(const Params &params,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.h
@@ -72,6 +72,7 @@ protected:
     }
     JitConstants GetJitConstants(const fully_connected_params& params, const DispatchData& dispatchData) const override;
     bool Validate(const Params& params, const optional_params& options) const override;
+    void GetUpdateDispatchDataFunc(KernelData& kd) const override;
 
     tune_params GetAutoTuneParams(const fully_connected_params& params, KernelType preffered_kernel_type = KernelType::DEFAULT, int idx = -1) const;
 


### PR DESCRIPTION
I moved the part to update `update_dispatch_data_func` into an overrided function `GetUpdateDispatchDataFunc`.
This change is necessary for model caching of dynamic models.
Please merge this patch to your PR.